### PR TITLE
Modernize plus sec updates

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,5 +1,9 @@
 set shell := ["nu", "-c"]
 set positional-arguments
+
+alias terraform := tofu
+alias tf := tofu
+
 AWS_PROFILE := 'cardano-monitoring'
 AWS_REGION := 'eu-central-1'
 WORKSPACE := 'cluster'
@@ -13,22 +17,19 @@ checkSshConfig := '''
   }
 '''
 
+# List all just recipes available
 default:
   @just --list
 
-lint:
-  deadnix -f
-  statix check -i .direnv
-
-show-flake *ARGS:
-  nix flake show {{ARGS}}
-
+# Deploy select machines
 apply *ARGS:
   colmena apply --keep-result --verbose --on {{ARGS}}
 
+# Deploy all machines
 apply-all *ARGS:
   colmena apply --keep-result --verbose {{ARGS}}
 
+# Deploy select machines with the bootstrap key
 apply-bootstrap HOSTNAME:
   #!/usr/bin/env nu
   {{checkSshConfig}}
@@ -43,96 +44,221 @@ apply-bootstrap HOSTNAME:
     SSH_CONFIG_FILE: .ssh_config_bootstrap
   } {
     print $"SSH_CONFIG_FILE: ($env.SSH_CONFIG_FILE)"
-    colmena apply --impure --keep-result --verbose --on {{HOSTNAME}}
+    colmena apply --keep-result --verbose --on {{HOSTNAME}}
   }
 
+# Generate repo docs
+book:
+  tofu fmt docs/grafana.tf
+  mdbook build docs/
+
+# Build a nixos configuration
 build-machine MACHINE *ARGS:
   nix build -L .#nixosConfigurations.{{MACHINE}}.config.system.build.toplevel {{ARGS}}
 
+# Build all nixosConfigurations
 build-machines *ARGS:
   #!/usr/bin/env nu
   let nodes = (nix eval --json '.#nixosConfigurations' --apply builtins.attrNames | from json)
   for node in $nodes {just build-machine $node {{ARGS}}}
 
-scp *ARGS:
-  #!/usr/bin/env nu
-  {{checkSshConfig}}
-  scp -o LogLevel=ERROR -F .ssh_config {{ARGS}}
-
-ssh HOSTNAME *ARGS:
-  #!/usr/bin/env nu
-  {{checkSshConfig}}
-  ssh -o LogLevel=ERROR -F .ssh_config {{HOSTNAME}} {{ARGS}}
-
-ssh-bootstrap HOSTNAME *ARGS:
-  #!/usr/bin/env nu
-  {{checkSshConfig}}
-  ssh -o LogLevel=ERROR -F .ssh_config -i .ssh_key {{HOSTNAME}} {{ARGS}}
-
-ssh-for-all *ARGS:
-  #!/usr/bin/env nu
-  let nodes = (nix eval --json '.#nixosConfigurations' --apply builtins.attrNames | from json)
-  $nodes | par-each {|node| just ssh -q $node {{ARGS}}}
-
-ssh-for-each HOSTNAMES *ARGS:
-  colmena exec --verbose --parallel 0 --on {{HOSTNAMES}} {{ARGS}}
-
-ssh-list-ips HOSTNAME_REGEX_PATTERN:
-  #!/usr/bin/env nu
-  {{checkSshConfig}}
-  ( scj dump /dev/stdout -c .ssh_config
-  | from json
-  | default "" Host
-  | default "" HostName
-  | where Host =~ {{HOSTNAME_REGEX_PATTERN}} and HostName != ""
-  | get HostName
-  | str join " " )
-
-ssh-list-names HOSTNAME_REGEX_PATTERN:
-  #!/usr/bin/env nu
-  {{checkSshConfig}}
-  ( scj dump /dev/stdout -c .ssh_config
-  | from json
-  | default "" Host
-  | default "" HostName
-  | where Host =~ {{HOSTNAME_REGEX_PATTERN}} and HostName != ""
-  | get Host
-  | str join " " )
-
+# Deploy a cloudFormation stack
 cf STACKNAME:
   #!/usr/bin/env nu
   nix eval --json '.#cloudFormation.{{STACKNAME}}' | from json | save --force '{{STACKNAME}}.json'
   rain deploy --debug --termination-protection --yes {{STACKNAME}}.json
 
-tf *ARGS:
-  tf {{ARGS}}
-
-# To describe instance types, any valid aws profile can be provided
-# Default region for specs will be eu-central-1 which provides ~600 machine definitions.
-update-aws-ec2-spec profile=AWS_PROFILE region=AWS_REGION:
+# Show the full kms key ARN
+kms:
   #!/usr/bin/env nu
-  let spec = (
-    do -c { aws ec2 --profile {{profile}} --region {{region}} describe-instance-types }
-    | from json
-    | get InstanceTypes
-    | select InstanceType MemoryInfo VCpuInfo
-    | reject VCpuInfo.ValidCores? VCpuInfo.ValidThreadsPerCore?
-    | sort-by InstanceType
+  ( aws kms list-aliases
+  | from json
+  | get Aliases
+  | where AliasName == "alias/kmsKey"
+  | get AliasArn.0 )
+
+# Standard lint check
+lint:
+  deadnix -f
+  statix check -i .direnv
+
+# List machines in the cluster
+list-machines:
+  #!/usr/bin/env nu
+
+  def safe-run [block msg] {
+    let res = (do -i $block | complete)
+    if $res.exit_code != 0 {
+      print $msg
+      print "The output was:"
+      print
+      print $res
+      exit 1
+    }
+    $res.stdout
+  }
+
+  def default-row [machine] {
+    {
+      Name: $machine,
+      Nix: $"(ansi green)OK",
+      pubIpv4: $"(ansi red)--",
+      # pubIpv6: $"(ansi red)--",
+      Id: $"(ansi red)--",
+      Type: $"(ansi red)--"
+      Region: $"(ansi red)--"
+    }
+  }
+
+  def main [] {
+    {{checkSshConfig}}
+
+    let nixosJson = (safe-run { ^nix eval --json ".#nixosConfigurations" --apply "builtins.attrNames" } "Nix eval failed.")
+    let sshJson = (safe-run { ^scj dump /dev/stdout -c .ssh_config } "scj failed.")
+
+    let baseTable = ($nixosJson | from json | each { |it| default-row $it })
+    let sshTable = ($sshJson | from json | where {|e| $e | get -i HostName | is-not-empty } | reject -i ProxyCommand)
+
+    let mergeTable = (
+      $sshTable | reduce --fold $baseTable { |it, acc|
+        let host = $it.Host
+        let hostData = $it.HostName
+        let machine = ($host | str replace -r '\.ipv(4|6)$' '')
+
+        let update = if ($host | str ends-with ".ipv4") {
+          { pubIpv4: $hostData, Region: $it.Tag }
+        # } else if ($host | str ends-with ".ipv6") {
+        #   { pubIpv6: $hostData }
+        } else {
+          { Id: $hostData, Type: $it.Tag }
+        }
+
+        if ($acc | any {|row| $row.Name == $machine }) {
+          $acc | each {|row|
+            if $row.Name == $machine {
+              $row | merge $update
+            } else {
+              $row
+            }
+          }
+        } else {
+          $acc ++ [ (default-row $machine | merge $update) ]
+        }
+      }
+    )
+
+    $mergeTable
+      | sort-by Name
+      | enumerate
+      | each { |r| { index: ($r.index + 1) } | merge $r.item }
+  }
+
+# Alias for list-machines recipe
+ls:
+  @just list-machines
+
+# Bootstrap a mimir url
+mimir-bootstrap URL:
+  # URL example: https://playground.monitoring.aws.iohkdev.io/mimir
+  if not ('fallback.yml' | path exists) { print "Please create a fallback.yml file"; exit }
+  mimirtool alertmanager load --log.level=debug --address {{URL}} --id anonymous fallback.yml
+
+# Scp using repo ssh config
+scp *ARGS:
+  #!/usr/bin/env nu
+  {{checkSshConfig}}
+  scp -o LogLevel=ERROR -F .ssh_config {{ARGS}}
+
+# Show nix flake details
+show-flake *ARGS:
+  nix flake show --allow-import-from-derivation {{ARGS}}
+
+# Ssh using repo ssh config
+ssh HOSTNAME *ARGS:
+  #!/usr/bin/env nu
+  {{checkSshConfig}}
+  ssh -o LogLevel=ERROR -F .ssh_config {{HOSTNAME}} {{ARGS}}
+
+# Ssh using cluster bootstrap key
+ssh-bootstrap HOSTNAME *ARGS:
+  #!/usr/bin/env nu
+  {{checkSshConfig}}
+  ssh -o LogLevel=ERROR -F .ssh_config -i .ssh_key {{HOSTNAME}} {{ARGS}}
+
+# Ssh to all
+ssh-for-all *ARGS:
+  #!/usr/bin/env nu
+  let nodes = (nix eval --json '.#nixosConfigurations' --apply builtins.attrNames | from json)
+  $nodes | par-each {|node|
+    let result = (do -i { ^just ssh -q $node {{ARGS}} } | complete)
+    {
+      index: $node,
+      result: $result
+    }
+  }
+
+# Ssh for select
+ssh-for-each HOSTNAMES *ARGS:
+  colmena exec --verbose --parallel 0 --on {{HOSTNAMES}} {{ARGS}}
+
+# List machine id, ipv4, name, region or type based on regex pattern
+ssh-list TYPE PATTERN:
+  #!/usr/bin/env nu
+  const type = "{{TYPE}}"
+
+  let sshCfg = (
+    scj dump /dev/stdout -c .ssh_config
+      | from json
+      | default "" Host
+      | default "" HostName
   )
-  mkdir flakeModules/aws/
-  {InstanceTypes: $spec} | save --force flakeModules/aws/ec2-spec.json
 
-show-nameservers:
-  #!/usr/bin/env nu
-  let domain = (nix eval --raw '.#cluster.infra.aws.domain')
-  let zones = (aws route53 list-hosted-zones-by-name | from json).HostedZones
-  let id = ($zones | where Name == $"($domain).").Id.0
-  let sets = (aws route53 list-resource-record-sets --hosted-zone-id $id | from json).ResourceRecordSets
-  let ns = ($sets | where Type == "NS").ResourceRecords.0.Value
-  print "Nameservers for the following hosted zone need to be added to the NS record of the delegating authority"
-  print $"Nameservers for domain: ($domain) \(hosted zone id: ($id)) are:"
-  print ($ns | to text)
+  if ($type == "id") {
+    $sshCfg
+      | where not ($it.Host =~ ".ipv(4|6)$")
+      | where Host =~ "{{PATTERN}}"
+      | get HostName
+      | str join " "
+  } else if ($type == "ipv4") {
+    $sshCfg
+      | where ($it.Host =~ ".ipv4$")
+      | where Host =~ "{{PATTERN}}"
+      | get HostName
+      | str join " "
+  # } else if ($type == "ipv6") {
+  #   $sshCfg
+  #     | where ($it.Host =~ ".ipv6$")
+  #     | where Host =~ "{{PATTERN}}"
+  #     | get HostName
+  #     | str join " "
+  } else if ($type == "name") {
+    $sshCfg
+      | where not ($it.Host =~ ".ipv(4|6)$")
+      | where Host =~ "{{PATTERN}}"
+      | get Host
+      | str join " "
+  } else if ($type == "region") {
+    $sshCfg
+      | where ($it.Host =~ ".ipv4$")
+      | where Host =~ "{{PATTERN}}"
+      | get Tag
+      | str join " "
+  } else if ($type == "type") {
+    $sshCfg
+      | where not ($it.Host =~ ".ipv(4|6)$")
+      | where Host =~ "{{PATTERN}}"
+      | get Tag
+      | str join " "
+  } else {
+    # print "The TYPE must be one of: id, ipv4, ipv6, name, region or type"
+    print "The TYPE must be one of: id, ipv4, name, region or type"
+  }
 
+# Run tofu cmds
+tofu *ARGS:
+  tofu {{ARGS}}
+
+# Save the cluster bootstrap ssh key
 save-bootstrap-ssh-key:
   #!/usr/bin/env nu
   print "Retrieving ssh key from tofu..."
@@ -144,6 +270,19 @@ save-bootstrap-ssh-key:
   $key.values.private_key_openssh | save .ssh_key
   chmod 0600 .ssh_key
 
+# Show DNS nameservers
+show-nameservers:
+  #!/usr/bin/env nu
+  let domain = (nix eval --raw '.#cluster.infra.aws.domain')
+  let zones = (aws route53 list-hosted-zones-by-name | from json).HostedZones
+  let id = ($zones | where Name == $"($domain).").Id.0
+  let sets = (aws route53 list-resource-record-sets --hosted-zone-id $id | from json).ResourceRecordSets
+  let ns = ($sets | where Type == "NS").ResourceRecords.0.Value
+  print "Nameservers for the following hosted zone need to be added to the NS record of the delegating authority"
+  print $"Nameservers for domain: ($domain) \(hosted zone id: ($id)) are:"
+  print ($ns | to text)
+
+# Save ssh config
 save-ssh-config:
   #!/usr/bin/env nu
   print "Retrieving ssh config from tofu..."
@@ -156,52 +295,16 @@ save-ssh-config:
   chmod 0600 $env.SSH_CONFIG_FILE
   print $"Saved to ($env.SSH_CONFIG_FILE)"
 
-kms:
+# Update aws ec2 default machine spec
+update-aws-ec2-spec profile=AWS_PROFILE region=AWS_REGION:
   #!/usr/bin/env nu
-  ( aws kms list-aliases
-  | from json
-  | get Aliases
-  | where AliasName == "alias/kmsKey"
-  | get AliasArn.0 )
-
-# URL example: https://playground.monitoring.aws.iohkdev.io/mimir
-mimir-bootstrap URL:
-  if not ('fallback.yml' | path exists) { print "Please create a fallback.yml file"; exit }
-  mimirtool alertmanager load --log.level=debug --address {{URL}} --id anonymous fallback.yml
-
-book:
-  tofu fmt docs/grafana.tf
-  mdbook build docs/
-
-ls:
-  @just list-machines
-
-# List machines in the cluster
-list-machines:
-  #!/usr/bin/env nu
-  let nix = (
-    nix eval '.#nixosConfigurations'
-      --json
-      --apply 'n: (map (n: {name=n; in_nixos_conf = true;}) (builtins.attrNames n))'
-      | from json
-      | dfr into-df
-  )
-
-  let list = (
-    tofu show -json
+  let spec = (
+    do -c { aws ec2 --profile {{profile}} --region {{region}} describe-instance-types }
     | from json
-    | get values.root_module.resources
-    | where type == "aws_instance"
-    | each {|n|
-        {
-          name: $n.name,
-          public_ip: $n.values.public_ip,
-          private_ip: $n.values.private_ip
-        }
-      }
-    | dfr into-df
-    | dfr join --outer $nix name name
-    | dfr sort-by name
+    | get InstanceTypes
+    | select InstanceType MemoryInfo VCpuInfo
+    | reject VCpuInfo.ValidCores? VCpuInfo.ValidThreadsPerCore?
+    | sort-by InstanceType
   )
-
-  $list | dfr into-nu
+  mkdir flakeModules/aws/
+  {InstanceTypes: $spec} | save --force flakeModules/aws/ec2-spec.json

--- a/Justfile
+++ b/Justfile
@@ -1,9 +1,13 @@
+import? 'scripts/recipes/aws.just'
+
 set shell := ["nu", "-c"]
 set positional-arguments
 
 alias terraform := tofu
 alias tf := tofu
 
+# Defaults
+null := ""
 AWS_PROFILE := 'cardano-monitoring'
 AWS_REGION := 'eu-central-1'
 WORKSPACE := 'cluster'

--- a/flake.lock
+++ b/flake.lock
@@ -245,11 +245,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1751943650,
-        "narHash": "sha256-7orTnNqkGGru8Je6Un6mq1T8YVVU/O5kyW4+f9C1mZQ=",
+        "lastModified": 1753345091,
+        "narHash": "sha256-CdX2Rtvp5I8HGu9swBmYuq+ILwRxpXdJwlpg8jvN4tU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "88983d4b665fb491861005137ce2b11a9f89f203",
+        "rev": "3ff0e34b1383648053bba8ed03f201d3466f90c9",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -10,48 +10,16 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1720648950,
-        "narHash": "sha256-KyWe8TtaS3luk/5kh0ZkQPIqVw0ubCHPaGg8VJ84HDU=",
+        "lastModified": 1747252629,
+        "narHash": "sha256-3VbgOFf3pEo+HGB5vIPxOwe4R2M7qU+VJ+5iS4hBKqI=",
         "owner": "input-output-hk",
         "repo": "auth-keys-hub",
-        "rev": "fa14ce66c812509830e5703cfe00e03d06da57f0",
+        "rev": "dd1d9361407457d14bab8f946d10062c487304df",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "repo": "auth-keys-hub",
-        "type": "github"
-      }
-    },
-    "bats-assert": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1636059754,
-        "narHash": "sha256-ewME0l27ZqfmAwJO4h5biTALc9bDLv7Bl3ftBzBuZwk=",
-        "owner": "bats-core",
-        "repo": "bats-assert",
-        "rev": "34551b1d7f8c7b677c1a66fc0ac140d6223409e5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "bats-core",
-        "repo": "bats-assert",
-        "type": "github"
-      }
-    },
-    "bats-support": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1548869839,
-        "narHash": "sha256-Gr4ntadr42F2Ks8Pte2D4wNDbijhujuoJi4OPZnTAZU=",
-        "owner": "bats-core",
-        "repo": "bats-support",
-        "rev": "d140a65044b2d6810381935ae7f0c94c7023c8c3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "bats-core",
-        "repo": "bats-support",
         "type": "github"
       }
     },
@@ -64,11 +32,11 @@
         "stable": "stable"
       },
       "locked": {
-        "lastModified": 1746816769,
-        "narHash": "sha256-ymQzXrfHVT8/RJiGbfrNjEeuzXQan46lUJdxEhgivdM=",
+        "lastModified": 1752070778,
+        "narHash": "sha256-2ArxrGPb39YxeyMgEzFX/YiUwwOgz62qazHhYJnZQss=",
         "owner": "zhaofengli",
         "repo": "colmena",
-        "rev": "df694ee23be7ed7b2d8b42c245a640f0724eb06c",
+        "rev": "f560ed613a568aee178576b21c6818ef50819ca5",
         "type": "github"
       },
       "original": {
@@ -111,6 +79,27 @@
         "type": "github"
       }
     },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "terranix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1736143030,
+        "narHash": "sha256-+hu54pAoLDEZT9pjHlqL9DNzWz0NbUn8NEAHP7PQPzU=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "b905f6fc23a9051a6e1b741e1438dbfc0634c6de",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1659877975,
@@ -118,21 +107,6 @@
         "owner": "numtide",
         "repo": "flake-utils",
         "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "locked": {
-        "lastModified": 1634851050,
-        "narHash": "sha256-N83GlSGPJJdcqhUxSCS/WwW5pksYf3VP1M13cDRTSVA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "c91f3de5adaf1de973b797ef7485e441a65b8935",
         "type": "github"
       },
       "original": {
@@ -169,11 +143,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1692634754,
-        "narHash": "sha256-9CzX+GEAEWod4hUdBXMsldCnQZS0W64ChgnrnA0vpCU=",
+        "lastModified": 1741904425,
+        "narHash": "sha256-s/M0Pa+4pm64BZT4nfsQMTNUZcsvvdfBhvEM5BrxaTQ=",
         "owner": "input-output-hk",
         "repo": "inputs-check",
-        "rev": "440d3915d5a387febc02a87637ca3ec516dd95d1",
+        "rev": "54a0f366a6ab2c17a9cf3b97aa4e0b96083373e1",
         "type": "github"
       },
       "original": {
@@ -237,22 +211,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-stable": {
-      "locked": {
-        "lastModified": 1700342017,
-        "narHash": "sha256-HaibwlWH5LuqsaibW3sIVjZQtEM/jWtOHX4Nk93abGE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "decdf666c833a325cb4417041a90681499e06a41",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "release-23.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1680945546,
@@ -271,11 +229,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1746461020,
-        "narHash": "sha256-7+pG1I9jvxNlmln4YgnlW4o+w0TZX24k688mibiFDUE=",
+        "lastModified": 1750134718,
+        "narHash": "sha256-v263g4GbxXv87hMXMCpjkIxd/viIF7p3JpJrwgKdNiI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3730d8a308f94996a9ba7c7138ede69c1b9ac4ae",
+        "rev": "9e83b64f727c88a7711a2c463a7b16eedb69a84c",
         "type": "github"
       },
       "original": {
@@ -304,11 +262,11 @@
     "opentofu-registry": {
       "flake": false,
       "locked": {
-        "lastModified": 1701094912,
-        "narHash": "sha256-XagoThrZj4xAW76TzjCv5kDJapEOV8m1Vz+VKPR4Prc=",
+        "lastModified": 1752094118,
+        "narHash": "sha256-n3GMRb4owfVlA2EqM+1eOUDFkqtwRZr/UyDD+OEqptg=",
         "owner": "opentofu",
         "repo": "registry-stable",
-        "rev": "39e756f83a573cfa1de162ff9983d68c21c9d782",
+        "rev": "663f4c33aa7942329b5705b178c533741f4595e4",
         "type": "github"
       },
       "original": {
@@ -334,15 +292,14 @@
       "inputs": {
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "nixpkgs-stable": "nixpkgs-stable"
+        ]
       },
       "locked": {
-        "lastModified": 1700362823,
-        "narHash": "sha256-/H7XgvrYM0IbkpWkcdfkOH0XyBM5ewSWT1UtaLvOgKY=",
+        "lastModified": 1751606940,
+        "narHash": "sha256-KrDPXobG7DFKTOteqdSVeL1bMVitDcy7otpVZWDE6MA=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "49a87c6c827ccd21c225531e30745a9a6464775c",
+        "rev": "3633fc4acf03f43b260244d94c71e9e14a2f6e0d",
         "type": "github"
       },
       "original": {
@@ -353,16 +310,16 @@
     },
     "stable": {
       "locked": {
-        "lastModified": 1746557022,
-        "narHash": "sha256-QkNoyEf6TbaTW5UZYX0OkwIJ/ZMeKSSoOMnSDPQuol0=",
+        "lastModified": 1750133334,
+        "narHash": "sha256-urV51uWH7fVnhIvsZIELIYalMYsyr2FCalvlRTzqWRw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1d3aeb5a193b9ff13f63f4d9cc169fb88129f860",
+        "rev": "36ab78dab7da2e4e27911007033713bab534187b",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.11",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -382,42 +339,40 @@
         "type": "github"
       }
     },
-    "terranix": {
-      "inputs": {
-        "bats-assert": "bats-assert",
-        "bats-support": "bats-support",
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "terranix-examples": "terranix-examples"
-      },
+    "systems": {
       "locked": {
-        "lastModified": 1695406838,
-        "narHash": "sha256-xiUfVD6rtsVWFotVtUW3Q1nQh4obKzgvpN1wqZuGXvM=",
-        "owner": "terranix",
-        "repo": "terranix",
-        "rev": "fc9077ca02ab5681935dbf0ecd725c4d889b9275",
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
         "type": "github"
       },
       "original": {
-        "owner": "terranix",
-        "repo": "terranix",
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     },
-    "terranix-examples": {
+    "terranix": {
+      "inputs": {
+        "flake-parts": "flake-parts_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1636300201,
-        "narHash": "sha256-0n1je1WpiR6XfCsvi8ZK7GrpEnMl+DpwhWaO1949Vbc=",
+        "lastModified": 1749381683,
+        "narHash": "sha256-16z7tXZch12SAd3d8tbAiEOamyq3zFbw1oUq/ipmTkM=",
         "owner": "terranix",
-        "repo": "terranix-examples",
-        "rev": "a934aa1cf88f6bd6c6ddb4c77b77ec6e1660bd5e",
+        "repo": "terranix",
+        "rev": "9d2370279d595be9e728b68d29ff0b546d88e619",
         "type": "github"
       },
       "original": {
         "owner": "terranix",
-        "repo": "terranix-examples",
+        "repo": "terranix",
         "type": "github"
       }
     },
@@ -446,11 +401,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1699786194,
-        "narHash": "sha256-3h3EH1FXQkIeAuzaWB+nK0XK54uSD46pp+dMD3gAcB4=",
+        "lastModified": 1752055615,
+        "narHash": "sha256-19m7P4O/Aw/6+CzncWMAJu89JaKeMh3aMle1CNQSIwM=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "e82f32aa7f06bbbd56d7b12186d555223dc399d1",
+        "rev": "c9d477b5d5bd7f26adddd3f96cfd6a904768d4f9",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -262,11 +262,11 @@
     "opentofu-registry": {
       "flake": false,
       "locked": {
-        "lastModified": 1752094118,
-        "narHash": "sha256-n3GMRb4owfVlA2EqM+1eOUDFkqtwRZr/UyDD+OEqptg=",
+        "lastModified": 1748472432,
+        "narHash": "sha256-ANRP7FE1tJ5iCis7t6xUhHSAnCQyxsajDLuZBdHRAV8=",
         "owner": "opentofu",
-        "repo": "registry-stable",
-        "rev": "663f4c33aa7942329b5705b178c533741f4595e4",
+        "repo": "registry",
+        "rev": "23d891c951b0f6dfd0681f2236f6838d522b11a8",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -222,17 +222,17 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1720386169,
-        "narHash": "sha256-NGKVY4PjzwAa4upkGtAMz1npHGoRzWotlSnVlqI40mo=",
+        "lastModified": 1751943650,
+        "narHash": "sha256-7orTnNqkGGru8Je6Un6mq1T8YVVU/O5kyW4+f9C1mZQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "194846768975b7ad2c4988bdb82572c00222c0d7",
+        "rev": "88983d4b665fb491861005137ce2b11a9f89f203",
         "type": "github"
       },
       "original": {
         "dir": "lib",
         "owner": "NixOS",
-        "ref": "nixos-24.05",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -287,16 +287,16 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1720691131,
-        "narHash": "sha256-CWT+KN8aTPyMIx8P303gsVxUnkinIz0a/Cmasz1jyIM=",
+        "lastModified": 1751943650,
+        "narHash": "sha256-7orTnNqkGGru8Je6Un6mq1T8YVVU/O5kyW4+f9C1mZQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a046c1202e11b62cbede5385ba64908feb7bfac4",
+        "rev": "88983d4b665fb491861005137ce2b11a9f89f203",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-24.05",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -14,10 +14,7 @@
 
     # Used for copying closures to the target machines.
     # We specify our cluster in flake/colmena.nix
-    colmena = {
-      url = "github:zhaofengli/colmena";
-      # inputs.nixpkgs.follows = "nixpkgs"; # XXX uncomment when updating nixpkgs
-    };
+    colmena.url = "github:zhaofengli/colmena";
 
     terranix = {
       url = "github:terranix/terranix";

--- a/flake.nix
+++ b/flake.nix
@@ -2,14 +2,14 @@
   description = "Cardano Monitoring cluster";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.05";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
 
     # flake-parts is used to structure this flake. It's particularly convenient
-    # for defining outputs for different systems. But also contains lets us
+    # for defining outputs for different systems. But also lets us
     # combine different modules.
     flake-parts = {
       url = "github:hercules-ci/flake-parts";
-      inputs.nixpkgs-lib.url = "github:NixOS/nixpkgs/nixos-24.05?dir=lib";
+      inputs.nixpkgs-lib.url = "github:NixOS/nixpkgs/nixos-25.05?dir=lib";
     };
 
     # Used for copying closures to the target machines.

--- a/flake/nixosModules/remove-ssh-bootstrap-key.nix
+++ b/flake/nixosModules/remove-ssh-bootstrap-key.nix
@@ -26,7 +26,6 @@
 
       services.remove-ssh-bootstrap-key = {
         wantedBy = ["multi-user.target"];
-        after = ["network-online.target"];
 
         serviceConfig = {
           Type = "oneshot";

--- a/perSystem/devShells.nix
+++ b/perSystem/devShells.nix
@@ -37,6 +37,8 @@
           nushell
           # Used for talking with CloudFormation
           rain
+          # Used for ssh sessions via aws scm
+          ssm-session-manager-plugin
           # Encryption
           sops
           # Used by `just lint`

--- a/perSystem/devShells.nix
+++ b/perSystem/devShells.nix
@@ -34,7 +34,7 @@
           # Mostly for the handy `sponge` command
           moreutils
           # Used for most scripts in the Justfile
-          nushellFull
+          nushell
           # Used for talking with CloudFormation
           rain
           # Encryption

--- a/perSystem/packages/opentofu.nix
+++ b/perSystem/packages/opentofu.nix
@@ -3,68 +3,78 @@
   lib,
   ...
 }: {
-  perSystem = {pkgs, ...}: {
-    packages.opentofu = let
-      mkTerraformProvider = {
-        owner,
-        repo,
-        version,
-        src,
-        registry ? "registry.opentofu.org",
-      }: let
-        inherit (pkgs.go) GOARCH GOOS;
-        provider-source-address = "${registry}/${owner}/${repo}";
-      in
-        pkgs.stdenv.mkDerivation {
-          pname = "terraform-provider-${repo}";
-          inherit version src;
+  perSystem = {pkgs, ...}:
+    with builtins;
+    with lib;
+    with pkgs; {
+      packages.opentofu = let
+        mkTerraformProvider = {
+          owner,
+          repo,
+          version,
+          src,
+          registry ? "registry.opentofu.org",
+        }: let
+          inherit (pkgs.go) GOARCH GOOS;
+          provider-source-address = "${registry}/${owner}/${repo}";
+        in
+          pkgs.stdenv.mkDerivation {
+            pname = "terraform-provider-${repo}";
+            inherit version src;
 
-          unpackPhase = "unzip -o $src";
+            unpackPhase = "unzip -o $src";
 
-          nativeBuildInputs = [pkgs.unzip];
+            nativeBuildInputs = [pkgs.unzip];
 
-          buildPhase = ":";
+            buildPhase = ":";
 
-          # The upstream terraform wrapper assumes the provider filename here.
-          installPhase = ''
-            dir=$out/libexec/terraform-providers/${provider-source-address}/${version}/${GOOS}_${GOARCH}
-            mkdir -p "$dir"
-            mv terraform-* "$dir/"
-          '';
+            # The upstream terraform wrapper assumes the provider filename here.
+            installPhase = ''
+              dir=$out/libexec/terraform-providers/${provider-source-address}/${version}/${GOOS}_${GOARCH}
+              mkdir -p "$dir"
+              mv terraform-* "$dir/"
+            '';
 
-          passthru = {
-            inherit provider-source-address;
+            passthru = {
+              inherit provider-source-address;
+            };
           };
-        };
 
-      readJSON = f: builtins.fromJSON (lib.readFile f);
+        readJSON = f: builtins.fromJSON (lib.readFile f);
 
-      # fetch the latest version
-      providerFor = owner: repo: let
-        json = readJSON (inputs.opentofu-registry + "/providers/${lib.substring 0 1 owner}/${owner}/${repo}.json");
-        latest = lib.head json.versions;
-        matching = lib.filter (e: e.os == "linux" && e.arch == "amd64") latest.targets;
-        target = lib.head matching;
-      in
-        mkTerraformProvider {
-          inherit (latest) version;
-          inherit owner repo;
-          src = pkgs.fetchurl {
-            url = target.download_url;
-            sha256 = target.shasum;
+        # fetch the latest version
+        providerFor = owner: repo: let
+          json = readJSON (inputs.opentofu-registry + "/providers/${lib.substring 0 1 owner}/${owner}/${repo}.json");
+
+          # Recent commits in opentofu-registry often append a version suffix of `-{alpha,beta}[0-9]+$`.
+          # Tofu won't initialize these alpha and beta packages by default, so filter them out.
+          stable = filter (e: match "^[0-9]+\.[0-9]+\.[0-9]+$" e.version != null) json.versions;
+
+          latest = head stable;
+
+          matching = filter (e: e.os == "linux" && e.arch == "amd64") latest.targets;
+          target = head matching;
+        in
+          mkTerraformProvider {
+            inherit (latest) version;
+            inherit owner repo;
+            src = pkgs.fetchurl {
+              url = target.download_url;
+              sha256 = target.shasum;
+            };
           };
-        };
-    in
-      pkgs.opentofu.withPlugins (_: [
-        (providerFor "fgouteroux" "loki")
-        (providerFor "fgouteroux" "mimir")
-        (providerFor "grafana" "grafana")
-        (providerFor "opentofu" "aws")
-        (providerFor "opentofu" "local")
-        (providerFor "opentofu" "external")
-        (providerFor "opentofu" "null")
-        (providerFor "opentofu" "tls")
-        (providerFor "loafoe" "ssh")
-      ]);
-  };
+      in
+        pkgs.opentofu.withPlugins (_: [
+          (providerFor "fgouteroux" "loki")
+          (providerFor "fgouteroux" "mimir")
+          (providerFor "grafana" "grafana")
+          (providerFor "opentofu" "aws")
+          (providerFor "opentofu" "awscc")
+          (providerFor "opentofu" "local")
+          (providerFor "opentofu" "external")
+          (providerFor "opentofu" "null")
+          (providerFor "opentofu" "tls")
+          (providerFor "loafoe" "ssh")
+        ]);
+    };
 }

--- a/scripts/recipes/aws.just
+++ b/scripts/recipes/aws.just
@@ -85,3 +85,32 @@ aws-sso-login AWS_PROFILE=null *ARGS:
 
   echo
   aws sso login --profile "$PROFILE" {{ARGS}}
+
+# Deploy a cloudFormation stack
+cf STACKNAME:
+  #!/usr/bin/env nu
+  nix eval --json '.#cloudFormation.{{STACKNAME}}' | from json | save --force '{{STACKNAME}}.json'
+  rain deploy --debug --termination-protection --yes {{STACKNAME}}.json
+
+# Show the full kms key ARN
+kms:
+  #!/usr/bin/env nu
+  ( aws kms list-aliases
+  | from json
+  | get Aliases
+  | where AliasName == "alias/kmsKey"
+  | get AliasArn.0 )
+
+# Update aws ec2 default machine spec
+update-aws-ec2-spec profile=AWS_PROFILE region=AWS_REGION:
+  #!/usr/bin/env nu
+  let spec = (
+    do -c { aws ec2 --profile {{profile}} --region {{region}} describe-instance-types }
+    | from json
+    | get InstanceTypes
+    | select InstanceType MemoryInfo VCpuInfo
+    | reject VCpuInfo.ValidCores? VCpuInfo.ValidThreadsPerCore?
+    | sort-by InstanceType
+  )
+  mkdir flakeModules/aws/
+  {InstanceTypes: $spec} | save --force flakeModules/aws/ec2-spec.json

--- a/scripts/recipes/aws.just
+++ b/scripts/recipes/aws.just
@@ -1,0 +1,87 @@
+# AWS specific recipes related to non-Tofu infrastructure.
+# Doing so will make diffing and patching the main repo Justfile easier.
+
+# Describe an aws ec2 machine
+aws-ec2-describe NAME REGION *ARGS:
+  #!/usr/bin/env bash
+  set -e
+  ID=$(just aws-ec2-id {{NAME}} {{REGION}})
+  aws --region {{REGION}} ec2 describe-instances --instance-ids "$ID" {{ARGS}}
+
+# Get an aws ec2 machine id
+aws-ec2-id NAME REGION:
+  #!/usr/bin/env bash
+  set -e
+  ID=$(aws --region {{REGION}} ec2 describe-instances --filters "Name=tag:Name,Values={{NAME}}" --output text --query "Reservations[*].Instances[*].InstanceId")
+  if [ -z "${ID:-}" ]; then
+    echo >&2 "ERROR: Machine {{NAME}} not found in region {{REGION}}"
+    exit 1
+  fi
+  echo "$ID"
+
+# Start an aws ec2 machine
+aws-ec2-start NAME REGION *ARGS:
+  #!/usr/bin/env bash
+  set -e
+  ID=$(just aws-ec2-id {{NAME}} {{REGION}})
+  aws --region {{REGION}} ec2 start-instances --instance-ids "$ID" {{ARGS}}
+
+# Get an aws ec2 machine status
+aws-ec2-status NAME REGION *ARGS:
+  #!/usr/bin/env bash
+  set -e
+  ID=$(just aws-ec2-id {{NAME}} {{REGION}})
+  aws --region {{REGION}} ec2 describe-instance-status --include-all-instances --instance-ids "$ID" {{ARGS}}
+
+# Stop an aws ec2 machine
+aws-ec2-stop NAME REGION *ARGS:
+  #!/usr/bin/env bash
+  set -e
+  ID=$(just aws-ec2-id {{NAME}} {{REGION}})
+  aws --region {{REGION}} ec2 stop-instances --instance-ids "$ID" {{ARGS}}
+
+# Describe ssm active sessions
+aws-ssm-sessions *ARGS:
+  #!/usr/bin/env bash
+  set -e
+  aws ssm describe-sessions --state Active {{ARGS}}
+
+# Export short term aws sso credentials
+aws-sso-export FILE="aws-sso.sh" AWS_PROFILE=null *ARGS:
+  #!/usr/bin/env bash
+  set -e
+  if [ -n "{{AWS_PROFILE}}" ]; then
+    PROFILE="{{AWS_PROFILE}}"
+    echo "Exporting short term AWS SSO credentials for profile \"$PROFILE\" to file: {{FILE}}..."
+  elif [ -n "$AWS_PROFILE" ]; then
+    PROFILE="$AWS_PROFILE"
+    echo "Exporting short term AWS SSO credentials for profile \"$PROFILE\" from env var AWS_PROFILE to file {{FILE}}..."
+  else
+    echo "ERROR: Either a recipe AWS_PROFILE arg must be given or the env var AWS_PROFILE must be set."
+  fi
+
+  if ! aws sts get-caller-identity --profile "$AWS_PROFILE" &> /dev/null; then
+    echo
+    nu -c 'print $"(ansi "bg_light_red")Please run:(ansi reset) `just aws-sso-login` first to obtain sso credentials"'
+    exit 1
+  fi
+
+  echo
+  aws configure export-credentials --format env *ARGS > {{FILE}}
+
+# Login to aws sso
+aws-sso-login AWS_PROFILE=null *ARGS:
+  #!/usr/bin/env bash
+  set -e
+  if [ -n "{{AWS_PROFILE}}" ]; then
+    PROFILE="{{AWS_PROFILE}}"
+    echo "Logging into AWS SSO using profile \"$PROFILE\" from cli..."
+  elif [ -n "$AWS_PROFILE" ]; then
+    PROFILE="$AWS_PROFILE"
+    echo "Logging into AWS SSO using profile \"$PROFILE\" from env var AWS_PROFILE..."
+  else
+    echo "ERROR: Either a recipe AWS_PROFILE arg must be given or the env var AWS_PROFILE must be set."
+  fi
+
+  echo
+  aws sso login --profile "$PROFILE" {{ARGS}}

--- a/scripts/recipes/aws.just
+++ b/scripts/recipes/aws.just
@@ -60,14 +60,14 @@ aws-sso-export FILE="aws-sso.sh" AWS_PROFILE=null *ARGS:
     echo "ERROR: Either a recipe AWS_PROFILE arg must be given or the env var AWS_PROFILE must be set."
   fi
 
-  if ! aws sts get-caller-identity --profile "$AWS_PROFILE" &> /dev/null; then
+  if ! aws sts get-caller-identity --profile "$AWS_PROFILE" | grep "arn:aws:sts" &> /dev/null; then
     echo
     nu -c 'print $"(ansi "bg_light_red")Please run:(ansi reset) `just aws-sso-login` first to obtain sso credentials"'
     exit 1
   fi
 
   echo
-  aws configure export-credentials --format env *ARGS > {{FILE}}
+  aws configure export-credentials --format env {{ARGS}} > {{FILE}}
 
 # Login to aws sso
 aws-sso-login AWS_PROFILE=null *ARGS:


### PR DESCRIPTION
A modernization and security update PR that:
* Updates most flake pins, including nixpkgs from `24.05` -> `25.05`, colmena, auth-keys-hub, opentofu-registry
* Updates grafana to include patch fixes for CVE-2025-6023 and CVE-2025-6197 via nixpkgs bump
* Updates the opentofu-registry for aws provider `v5.98.0` after which there is an unresolved json marshalling bug
* Updates the opentofu package to filter problematic alpha/beta provider versions
* Updates the tofu cluster definition to the latest arm64 nixos ami
* Updates the tofu cluster to save ec2 id, type, region to ssh config
* Updates the just recipes to yield extended `list-machines` info (ec2 id, type, region)
* Migrates to ssh over ssm usage
* Migrates from deprecated grafana-agent to grafana alloy
* Cleans up the just recipes help output (`just list`)
* Adds aws specific recipes
* Fixes grafana and mimir race condition failures on reboot