### PR TITLE
Add new tags for CloudF and Tofu resources

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -245,14 +245,26 @@ ssh-list TYPE PATTERN:
 
 # Run tofu cmds
 tofu *ARGS:
-  #!/usr/bin/env nu
-  print $"Running tofu in the (ansi green){{WORKSPACE}}(ansi reset) workspace..."
+  #!/usr/bin/env bash
+  set -euo pipefail
+  IGREEN='\033[1;92m'
+  IRED='\033[1;91m'
+  NC='\033[0m'
+  SOPS=("sops" "--kms" "/dev/null" "--decrypt")
+
+  read -r -a ARGS <<< "{{ARGS}}"
+
+  unset VAR_FILE
+  if [ -s "secrets/{{WORKSPACE}}.tfvars.enc" ]; then
+    VAR_FILE="secrets/{{WORKSPACE}}.tfvars.enc"
+  fi
+
+  echo -e "Running tofu in the ${IGREEN}{{WORKSPACE}}${NC} workspace..."
   rm --force tofu.tf.json
   nix build ".#opentofu.{{WORKSPACE}}" --out-link tofu.tf.json
-
   tofu init -reconfigure
   tofu workspace select -or-create {{WORKSPACE}}
-  tofu {{ARGS}}
+  tofu "${ARGS[@]:0:1}" ${VAR_FILE:+-var-file=<("${SOPS[@]}" "$VAR_FILE")} "${ARGS[@]:1}"
 
 # Save the cluster bootstrap ssh key
 save-bootstrap-ssh-key:

--- a/flake/cloudFormation/state.nix
+++ b/flake/cloudFormation/state.nix
@@ -8,13 +8,34 @@
   flake.cloudFormation.state = let
     inherit (self.cluster.infra.aws) domain buckets;
 
-    tagWith = name: (lib.mapAttrsToList (Key: Value: {
-        inherit Key Value;
-      }) {
-        inherit (self.cluster.infra.generic) organization tribe function repo;
-        environment = "generic";
-        Name = name;
-      });
+    tagWith = name:
+      (lib.mapAttrsToList (n: v: {
+          Key = n;
+          Value = v;
+        }) {
+          inherit
+            (self.cluster.infra.generic)
+            environment
+            function
+            organization
+            owner
+            project
+            repo
+            tribe
+            ;
+        })
+      ++ [
+        {
+          Key = "Name";
+          Value = name;
+        }
+        {
+          Key = "costCenter";
+          Value = {
+            Ref = "costCenter";
+          };
+        }
+      ];
 
     mkBucket = name: {
       Type = "AWS::S3::Bucket";
@@ -44,6 +65,15 @@
   in {
     AWSTemplateFormatVersion = "2010-09-09";
     Description = "State handling";
+
+    # The costCenter parameter will be passed to the configuration via a secrets file.
+    # For details, see the just recipe: cf
+    Parameters = {
+      costCenter = {
+        Type = "String";
+        Description = "The costCenter tag";
+      };
+    };
 
     Resources =
       (lib.mapAttrs (_: mkBucket) buckets)

--- a/flake/cluster.nix
+++ b/flake/cluster.nix
@@ -66,11 +66,18 @@
 
     # Mostly generic key/values used for tagging resources.
     generic = {
-      organization = "iog";
+      organization = "ioe";
       tribe = "coretech";
       function = "cardano-monitoring";
       repo = "https://github.com/input-output-hk/cardano-monitoring";
-      environment = "generic";
+
+      # Tags below are required by IT/Finance
+      owner = "ioe";
+      environment = "monitoring";
+      project = "cardano-monitoring";
+
+      # This is the tf var secrets name located in secrets/cluster.tfvars.enc
+      costCenter = "tag_costCenter";
     };
   };
 }

--- a/flake/nixosModules/aws.nix
+++ b/flake/nixosModules/aws.nix
@@ -44,10 +44,7 @@
             delete_on_termination = true;
           };
 
-          # Setting tags on all our resources to adhere to:
-          # https://github.com/input-output-hk/sre-adrs/blob/master/decisions/0001-organize-infrastructure-via-tags.md
           tags = {
-            inherit (self.cluster.infra.generic) organization tribe function repo;
             environment = name;
             group = name;
             Name = name;

--- a/flake/opentofu/cluster.nix
+++ b/flake/opentofu/cluster.nix
@@ -49,6 +49,27 @@ with lib; let
 
   mapBuckets = fn: listToAttrs (map fn buckets);
 
+  sensitiveString = {
+    type = "string";
+    sensitive = true;
+    nullable = false;
+  };
+
+  defaultTags = {
+    inherit
+      (self.cluster.infra.generic)
+      environment
+      function
+      organization
+      owner
+      project
+      repo
+      tribe
+      ;
+
+    # costCenter is saved as a secret
+    costCenter = "\${var.${self.cluster.infra.generic.costCenter}}";
+  };
   allConfig = {
     terraform = {
       required_providers = {
@@ -66,10 +87,19 @@ with lib; let
       };
     };
 
+    variable = {
+      # costCenter tag should remain secret in public repos
+      "${self.cluster.infra.generic.costCenter}" = sensitiveString;
+    };
+
     provider.aws = forEach (attrNames aws.regions) (region: {
       inherit region;
       alias = underscore region;
-      default_tags.tags = self.cluster.infra.generic;
+
+      # Default tagging is inconsistent across aws resources, but including
+      # it may help tag some resources that might have otherwise been
+      # missed.
+      default_tags.tags = defaultTags;
     });
 
     resource = {
@@ -77,7 +107,7 @@ with lib; let
         inherit (node.aws) region;
       in
         {
-          inherit (node.aws.instance) count instance_type tags root_block_device;
+          inherit (node.aws.instance) count instance_type;
 
           provider = awsProviderFor node.aws.region;
           ami = "\${data.aws_ami.nixos_${underscore monitorSystem}_${underscore region}.id}";
@@ -86,6 +116,18 @@ with lib; let
           monitoring = true;
           key_name = "\${aws_key_pair.bootstrap_${underscore node.aws.region}[0].key_name}";
           vpc_security_group_ids = ["\${aws_security_group.common_${underscore node.aws.region}[0].id}"];
+
+          # Provider level `default_tags` are automatically inherited at
+          # the instance level.  Instance specific tags defined in
+          # flake/colmena.nix are merged.
+          tags = node.aws.instance.tags or {};
+
+          root_block_device =
+            node.aws.instance.root_block_device
+            // {
+              # Default tags are not inherited to the volume level automatically.
+              tags = defaultTags // node.aws.instance.tags or {};
+            };
 
           metadata_options = {
             http_endpoint = "enabled";
@@ -100,6 +142,7 @@ with lib; let
       aws_iam_instance_profile.ec2_profile = {
         name = "ec2Profile";
         role = "\${aws_iam_role.ec2_role.name}";
+        tags = defaultTags;
       };
 
       aws_iam_role.ec2_role = {
@@ -114,6 +157,7 @@ with lib; let
             }
           ];
         };
+        tags = defaultTags;
       };
 
       aws_s3_bucket_policy = mapBuckets (bucket: {
@@ -170,6 +214,7 @@ with lib; let
             }
           ];
         };
+        tags = defaultTags;
       };
 
       aws_route53_record = mapNodes (name: _: {
@@ -191,13 +236,17 @@ with lib; let
           provider = awsProviderFor region;
           key_name = "bootstrap";
           public_key = "\${tls_private_key.bootstrap.public_key_openssh}";
+          tags = defaultTags;
         };
       });
 
       aws_eip = mapNodes (name: node: {
-        inherit (node.aws.instance) count tags;
+        inherit (node.aws.instance) count;
         provider = awsProviderFor node.aws.region;
         instance = "\${aws_instance.${name}[0].id}";
+
+        # Provider level `default_tags` are automatically inherited.
+        tags = node.aws.instance.tags or {};
       });
 
       aws_eip_association = mapNodes (name: node: {
@@ -248,6 +297,8 @@ with lib; let
               protocol = "-1";
             }
           ];
+
+          tags = defaultTags;
         };
       });
 
@@ -306,9 +357,17 @@ with lib; let
         };
       });
 
-      aws_s3_bucket = mapBuckets (bucket: {
-        name = bucket;
-        value = {inherit bucket;};
+      # Ref: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html
+      aws_availability_zones = mapRegions ({region, ...}: {
+        ${region} = {
+          provider = "aws.${region}";
+          filter = [
+            {
+              name = "opt-in-status";
+              values = ["opt-in-not-required"];
+            }
+          ];
+        };
       });
 
       aws_iam_policy_document = mapBuckets (bucket: {
@@ -329,7 +388,78 @@ with lib; let
           };
         };
       });
+
+      aws_internet_gateway = mapRegions ({region, ...}: {
+        ${region} = {
+          provider = "aws.${region}";
+          filter = [
+            {
+              name = "attachment.vpc-id";
+              values = ["\${data.aws_vpc.${region}.id}"];
+            }
+          ];
+          depends_on = ["data.aws_vpc.${region}"];
+        };
+      });
+
+      aws_route_table = mapRegions ({region, ...}: {
+        ${region} = {
+          provider = "aws.${region}";
+          route_table_id = "\${data.aws_vpc.${region}.main_route_table_id}";
+          depends_on = ["data.aws_vpc.${region}"];
+        };
+      });
+
+      aws_s3_bucket = mapBuckets (bucket: {
+        name = bucket;
+        value = {inherit bucket;};
+      });
+
+      aws_subnet = mapRegions ({region, ...}: {
+        ${region} = {
+          provider = "aws.${region}";
+          # The index of the map is used to assign an ipv6 subnet network
+          # id offset in the aws_default_subnet ipv6_cidr_block resource
+          # arg.
+          #
+          # While az ids are consistent across aws orgs, they are not
+          # implemented in all regions, therefore we'll use az names as
+          # indexed values.
+          #
+          # Ref:
+          #   https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet#availability_zone_id
+          #
+          for_each = "\${{for i, az in data.aws_availability_zones.${region}.names : i => az}}";
+          availability_zone = "\${element(data.aws_availability_zones.${region}.names, each.key)}";
+          default_for_az = true;
+        };
+      });
+
+      aws_vpc = mapRegions ({region, ...}: {
+        ${region} = {
+          provider = "aws.${region}";
+          default = true;
+        };
+      });
     };
+
+    # Debug output
+    # output =
+    #   mapRegions ({region, ...}: {
+    #     "aws_availability_zones_${region}".value = "\${data.aws_availability_zones.${region}.names}";
+    #   })
+    #   // mapRegions ({region, ...}: {
+    #     "aws_internet_gateway_${region}".value = "\${data.aws_internet_gateway.${region}}";
+    #   })
+    #   // mapRegions ({region, ...}: {
+    #     "aws_route_table_${region}".value = "\${data.aws_route_table.${region}}";
+    #   })
+    #   // mapRegions ({region, ...}: {
+    #     "aws_subnet_${region}".value = "\${data.aws_subnet.${region}}";
+    #   })
+    #   // mapRegions ({region, ...}: {
+    #     "aws_vpc_${region}".value = "\${data.aws_vpc.${region}}";
+    #   });
   };
 in {
   flake.opentofu.cluster = inputs.terranix.lib.terranixConfiguration {

--- a/scripts/recipes/aws.just
+++ b/scripts/recipes/aws.just
@@ -89,8 +89,18 @@ aws-sso-login AWS_PROFILE=null *ARGS:
 # Deploy a cloudFormation stack
 cf STACKNAME:
   #!/usr/bin/env nu
-  nix eval --json '.#cloudFormation.{{STACKNAME}}' | from json | save --force '{{STACKNAME}}.json'
-  rain deploy --debug --termination-protection --yes {{STACKNAME}}.json
+  mkdir cloudFormation
+  let secretName = (nix eval --raw '.#cluster.infra.generic.costCenter')
+  let costCenter = (
+    sops --kms /dev/null -d secrets/cluster.tfvars.enc
+    | lines
+    | where { |it| $it =~ $secretName }
+    | parse $"($secretName) = \"{secret}\""
+    | get 0.secret
+    | to text
+  )
+  nix eval --json '.#cloudFormation.{{STACKNAME}}' | from json | save --force 'cloudFormation/{{STACKNAME}}.json'
+  rain deploy --debug --params costCenter=($costCenter) --termination-protection ./cloudFormation/{{STACKNAME}}.json
 
 # Show the full kms key ARN
 kms:

--- a/secrets/cluster.tfvars.enc
+++ b/secrets/cluster.tfvars.enc
@@ -1,0 +1,17 @@
+{
+	"data": "ENC[AES256_GCM,data:NDkdwQO6q1I8E0umq9CYDRO89SRzKlIUKA==,iv:ChAnN2+0rOx9ELB0unC1WG8M2P2lh2TC1Zw4rnb8L3Q=,tag:JqrL9kCwkcS4vaSENYp8rg==,type:str]",
+	"sops": {
+		"kms": [
+			{
+				"arn": "arn:aws:kms:eu-central-1:463886338519:alias/kmsKey",
+				"created_at": "2025-11-08T03:59:40Z",
+				"enc": "AQICAHgvfnO+wlcXYoD+bXoOtLaOdiwzl0zs7N1eXxZo3hhaEwGiSt/yIx1c+Se9nVbWLpwwAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMgdHHGBnV1VP13u47AgEQgDvvkPcdjed/o65OPZNELJzZXa1I3k3FUGz5ehh1Hcw753Y68rBrvQtyTdeXF/zvo7ZUq2S8B1rawgRgbA==",
+				"aws_profile": ""
+			}
+		],
+		"lastmodified": "2025-11-08T03:59:40Z",
+		"mac": "ENC[AES256_GCM,data:MRDp5gByXBshbzUXpCJRzePURSM/b35XHE0vH0eNa36idrXNt6hul68Rc74fpgLbJ6Su73sMHOvAUIJYdDQ1XG7qbABX5O89OU483yPd05I80ev5xCdQOGxP5s3c9gwuXcbNwjhfDFASUindpoilboCE9YQlEx/J4Az/aON5mOw=,iv:G5ogYpVdLf+C66viowq/TzG3kSBpvCM6lYvyJbYi4SU=,tag:ShGKwsDZ8RIdMYN4Tcaqvg==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.10.2"
+	}
+}


### PR DESCRIPTION
* Adds new resource tags to both cloudFormation and tofu resources: `owner`, `project`, `costCenter`
* Updates the pre-existing `organization` and `environment` tags
* Treats costCenter tag as secret and adds a corresponding secrets file
* Updates justfile, cloudFormation state template and tofu cluster definition files to accommodate
* Adds some default resource tofu defns in prep for ipv6 and default resource tagging
