### PR TITLE
Add more loki

### DIFF
--- a/flake/cluster.nix
+++ b/flake/cluster.nix
@@ -44,11 +44,20 @@
         # Storing Mimir metrics for the playground cluster.
         playground = "${profile}-playground";
 
+        # Storing Loki logs for the playground cluster.
+        playgroundLoki = "${profile}-playground-loki";
+
         # Storing Mimir metrics for the mainnet cluster.
         mainnet = "${profile}-mainnet";
 
+        # Storing Loki logs for the mainnet cluster.
+        mainnetLoki = "${profile}-mainnet-loki";
+
         # Storing Mimir metrics for the networkteam cluster.
         networkteam = "${profile}-networkteam";
+
+        # Storing Loki logs for the networkteam cluster.
+        networkteamLoki = "${profile}-networkteam-loki";
 
         # Storing Mimir metrics for the devx-ci cluster.
         devxci = "${profile}-devxci";

--- a/flake/colmena.nix
+++ b/flake/colmena.nix
@@ -51,17 +51,20 @@
       playground = {
         aws.instance.root_block_device.volume_size = 100;
         services.mimir.configuration.limits.compactor_blocks_retention_period = lib.mkForce "10y";
+        services.loki.enable = true;
       };
 
       # Provides a place to store and view metrics for https://github.com/input-output-hk/cardano-mainnet
       mainnet = {
         aws.instance.root_block_device.volume_size = 100;
         services.mimir.configuration.limits.compactor_blocks_retention_period = lib.mkForce "10y";
+        services.loki.enable = true;
       };
 
       # Provides a place to store and view metrics for https://github.com/input-output-hk/ouroboros-network-ops
       networkteam = {
         aws.instance.root_block_device.volume_size = 100;
+        services.loki.enable = true;
       };
 
       # Provides a place to store and view metrics for https://github.com/input-output-hk/devx-ci

--- a/flake/colmena.nix
+++ b/flake/colmena.nix
@@ -47,27 +47,27 @@
       # Every attribute apart from `meta` and `defaults` defines a machine deployment.
       # These are empty right now because the default imports suffice.
 
-      # Provides a place to store and view metrics for https://github.com/input-output-hk/cardano-playground
+      # Provides a place to store and view metrics and logs for https://github.com/input-output-hk/cardano-playground
       playground = {
         aws.instance.root_block_device.volume_size = 100;
         services.mimir.configuration.limits.compactor_blocks_retention_period = lib.mkForce "10y";
         services.loki.enable = true;
       };
 
-      # Provides a place to store and view metrics for https://github.com/input-output-hk/cardano-mainnet
+      # Provides a place to store and view metrics and logs for https://github.com/input-output-hk/cardano-mainnet
       mainnet = {
         aws.instance.root_block_device.volume_size = 100;
         services.mimir.configuration.limits.compactor_blocks_retention_period = lib.mkForce "10y";
         services.loki.enable = true;
       };
 
-      # Provides a place to store and view metrics for https://github.com/input-output-hk/ouroboros-network-ops
+      # Provides a place to store and view metrics and logs for https://github.com/input-output-hk/ouroboros-network-ops
       networkteam = {
         aws.instance.root_block_device.volume_size = 100;
         services.loki.enable = true;
       };
 
-      # Provides a place to store and view metrics for https://github.com/input-output-hk/devx-ci
+      # Provides a place to store and view metrics and logs for https://github.com/input-output-hk/devx-ci
       devxci = {
         aws.instance.root_block_device.volume_size = 100;
         services.loki.enable = true;

--- a/flake/nixosModules/monitoring.nix
+++ b/flake/nixosModules/monitoring.nix
@@ -231,6 +231,9 @@ parts: {
             # Allow ingestion of out-of-order samples up to 5 minutes since the latest received sample for the series.
             limits.out_of_order_time_window = "5m";
 
+            # Help prevent "too many outstanding requests" errors.
+            frontend.max_outstanding_per_tenant = 256; # Default is 100
+
             server = {
               http_listen_port = 8080;
               http_listen_address = "127.0.0.1";


### PR DESCRIPTION
* Adds loki to playground, mainnet, networkteam monitoring servers
* Raises `max_outstanding_per_tenant` to accommodate large dashboards w/o errors